### PR TITLE
allow use of redis-namespace as redis client

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -15,7 +15,9 @@ class Redis
       @locked = false
       @name = args.shift.to_s
       @redis = args.pop
-      @redis = Redis.new(@redis) unless @redis.kind_of? Redis
+      if !(@redis.is_a?(Redis) || (defined?(Redis::Namespace) && @redis.is_a?(Redis::Namespace)))
+        @redis = Redis.new(@redis)
+      end
       @resources = args.pop || 1
       
     end


### PR DESCRIPTION
In my use case I needed to place all of my keys that I created under a top-level namespace.  I wanted to use the redis-namespace gem to accomplish this.  Let me know what you think.  Thanks!
