### PR TITLE
Add resource index to multiple resource semaphore

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -2,16 +2,16 @@ require 'redis'
 
 class Redis
   class Semaphore
-    
+
     attr_reader :resources
-    
+
     # RedisSempahore.new(:my_semaphore, 5, myRedis)
     # RedisSemaphore.new(:my_semaphore, myRedis)
     # RedisSemaphore.new(:my_semaphore, :connection => "", :port => "")
     # RedisSemaphore.new(:my_semaphore, :path => "bla")
     def initialize(*args)
       raise "Need at least two arguments" if args.size < 2
-      
+
       @locked = false
       @name = args.shift.to_s
       @redis = args.pop
@@ -19,69 +19,71 @@ class Redis
         @redis = Redis.new(@redis)
       end
       @resources = args.pop || 1
-      
+
     end
-    
+
     def available
       @redis.llen(list_name)
     end
-    
+
     def exists?
       @redis.exists(exists_name)
     end
-    
+
     def delete!
       @redis.del(list_name)
       @redis.del(exists_name)
     end
-    
+
     def lock(timeout = 0)
       exists_or_create!
-      
-      return false if @redis.blpop(list_name, timeout).nil?
-      
-      @locked = true
+
+
+      resource_index = @redis.blpop(list_name, timeout)
+      return false if resource_index.nil?
+
+      @locked = resource_index[1].to_i
       if block_given?
         begin
-          yield
+          yield @locked
         ensure
           unlock
         end
       end
-      
+
       true
     end
-    
+
     def unlock
       return false unless locked?
-      
-      @redis.rpush(list_name, 1)
+
+      @redis.lpush(list_name, @locked)
       @locked = false
     end
-    
+
     def locked?
-      @locked
+      !!@locked
     end
-    
-    
-  private  
+
+
+  private
     def list_name
       "SEMAPHORE::#{@name}::LIST"
     end
-    
+
     def exists_name
       "SEMAPHORE::#{@name}::EXISTS"
     end
-    
+
     def exists_or_create!
       exists = @redis.getset(exists_name, 1)
-      
+
       if "1" != exists
-        @resources.times do
-          @redis.lpush(list_name, 1)
+        @resources.times do |index|
+          @redis.rpush(list_name, index)
         end
       end
     end
-    
+
   end
 end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -18,36 +18,72 @@ describe "redis" do
   after(:all) do
     @redis.quit
   end
-  
+
   it "should be unlocked from the start" do
     @semaphore.locked?.should == false
   end
-  
+
   it "should lock and unlock" do
     @semaphore.lock
     @semaphore.locked?.should == true
     @semaphore.unlock
     @semaphore.locked?.should == false
   end
-  
+
   it "should not lock twice as a mutex" do
     @semaphore.lock
     @semaphore.lock(1).should == false
   end
-  
+
   it "should not lock three times when only two available" do
     multisem = Redis::Semaphore.new(:my_semaphore2, 2, @redis)
     multisem.lock.should == true
     multisem.lock(1).should == true
     multisem.lock(1).should == false
   end
-  
+
+  it "should reuse the same index for 5 calls in serial" do
+    multisem = Redis::Semaphore.new(:my_semaphore5_serial, 5, @redis)
+    ids = []
+    5.times do
+      multisem.lock(1) do |i|
+        ids << i
+      end
+    end
+    ids.size.should == 5
+    ids.uniq.size.should == 1
+  end
+
+  it "should have 5 different indexes for 5 parallel calls" do
+    multisem = Redis::Semaphore.new(:my_semaphore5_parallel, 5, @redis)
+    ids = []
+    multisem.lock(1) do |i|
+      ids << i
+      multisem.lock(1) do |i|
+        ids << i
+        multisem.lock(1) do |i|
+          ids << i
+          multisem.lock(1) do |i|
+            ids << i
+            multisem.lock(1) do |i|
+              ids << i
+              multisem.lock(1) do |i|
+                ids << i
+              end.should == false
+            end
+          end
+        end
+      end
+    end
+    (0..4).to_a.should == ids
+  end
+
   it "should execute the given code block" do
     code_executed = false
     @semaphore.lock do
       code_executed = true
     end
-    code_executed.should == true    
+    code_executed.should == true
   end
 
   it "should pass an exception right through" do
@@ -59,12 +95,12 @@ describe "redis" do
   end
 
   it "should not leave the semaphore locked after raising an exception" do
-    lambda do 
+    lambda do
       @semaphore.lock do
         raise Exception
       end
     end.should raise_error
-    
+
     @semaphore.locked?.should == false
   end
 end


### PR DESCRIPTION
We want to use this as a cross process connection pool. The call needs to look something like:

multisem = Redis::Semaphore.new(:my_semaphore5_parallel, 5, @redis)
multisem.lock(1) do |i|
  connection = Connection.new(config.users[i].username, config.users[i].password)
  connection.do_stuff
end
