### PR TITLE
Check if we use a Redis namespace, use single colon as node separator

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -68,11 +68,11 @@ class Redis
 
   private
     def list_name
-      "SEMAPHORE::#{@name}::LIST"
+      @redis.is_a?(Redis::Namespace) ? "#{@name}:LIST" : "SEMAPHORE:#{@name}:LIST"
     end
 
     def exists_name
-      "SEMAPHORE::#{@name}::EXISTS"
+      @redis.is_a?(Redis::Namespace) ? "#{@name}:EXISTS" : "SEMAPHORE:#{@name}:EXISTS"
     end
 
     def exists_or_create!


### PR DESCRIPTION
Hi,

Was using this, noticed empty nodes when using namespaces and solved that by using a single colon in exists_name and list_name they would disappear. Also I check if redis is a Redis::Namespace and in that case will not prepend SEMAPHORE.

Regards,
Ruurd
