### PR TITLE
Timeout should be specified in seconds not ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To allow for clients to die, and the token returned to the list, a stale-check w
 There are two ways to take advantage of this. You can either define a :stale\_client\_timeout upon initialization. This will check for stale locks everytime your program wants to lock the semaphore:
 
 ```ruby
-s = Redis::Semaphore.new(:stale_semaphore, :redis = r, :stale_client_timeout => 1000) # in ms
+s = Redis::Semaphore.new(:stale_semaphore, :redis = r, :stale_client_timeout => 5) # in seconds
 ```
 
 Or you could start a different thread or program that frequently checks for stale locks. This has the advantage of unblocking blocking calls to Semaphore#lock as well:
@@ -110,7 +110,7 @@ Or you could start a different thread or program that frequently checks for stal
 normal_sem = Redis::Semaphore.new(:semaphore, :connection => "localhost")
 
 Thread.new do
-  watchdog = Redis::Semaphore.new(:semaphore, :connection => "localhost", :stale_client_timeout => 1000)
+  watchdog = Redis::Semaphore.new(:semaphore, :connection => "localhost", :stale_client_timeout => 5)
   
   while(true) do
     watchdog.release_stale_locks!


### PR DESCRIPTION
Double-checked by reading the source code.

Also, contrary to the documentation, you cannot call `#release_stale_locks!` because it's a private method. I'm guessing either the docs or the API needs to be updated here but I'll leave it to you to make that call :)
