### PR TITLE
Fix current_time support for Redis versions < 2.6

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -184,8 +184,16 @@ class Redis
     end
 
     def current_time
-      instant = @redis.time
-      Time.at(instant[0], instant[1])
+      if server_version.to_f >= 2.6
+        instant = @redis.time
+        Time.at(instant[0], instant[1])
+      else
+        Time.now
+      end
+    end
+
+    def server_version
+      @redis.info['redis_version']
     end
   end
 end


### PR DESCRIPTION
This is a quick (and possibly dirty) fix for #15. I don't know if version-specific code paths are a no-no (I leave that up to @dv) but this does fix the issue.
