### PR TITLE
Make block-based locking return the value of the block.

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -54,16 +54,17 @@ class Redis
       current_token = token_pair[1]
       @tokens.push(current_token)
       @redis.hset(grabbed_key, current_token, current_time.to_f)
-      
+      return_value = current_token
+
       if block_given?
         begin
-          yield current_token
+          return_value = yield current_token
         ensure
           signal(current_token)
         end
       end
 
-      current_token
+      return_value
     end
     alias_method :wait, :lock
 

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -95,6 +95,23 @@ describe "redis" do
 
       expect(semaphore.locked?).to eq(false)
     end
+
+    it "should return the value of the block if block-style locking is used" do
+      block_value = semaphore.lock(1) do
+        42
+      end
+      expect(block_value).to eq(42)
+    end
+
+    it "can return the passed in token to replicate old behaviour" do
+      lock_token = semaphore.lock(1)
+      semaphore.unlock()
+
+      block_value = semaphore.lock(1) do |token|
+        token
+      end
+      expect(block_value).to eq(lock_token)
+    end
   end
 
   describe "semaphore without staleness checking" do


### PR DESCRIPTION
Block based operations in Ruby typically evaluate to the value of the
block.  Why should lock() be an exception?  You can accept the token and
evaluate that as the last thing to preserve current behaviour.
