### PR TITLE
Add support for an expiration option.

### DIFF
--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -114,6 +114,20 @@ describe "redis" do
     end
   end
 
+  describe "semaphore with expiration" do
+    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, :redis => @redis, :expiration => 2) }
+    let(:multisem) { Redis::Semaphore.new(:my_semaphore_2, :resources => 2, :redis => @redis, :expiration => 2) }
+
+    it_behaves_like "a semaphore"
+
+    it "expires keys" do
+      original_key_size = @redis.keys.count
+      semaphore.exists_or_create!
+      sleep 3.0
+      expect(@redis.keys.count).to eq(original_key_size)
+    end
+  end
+
   describe "semaphore without staleness checking" do
     let(:semaphore) { Redis::Semaphore.new(:my_semaphore, :redis => @redis) }
     let(:multisem) { Redis::Semaphore.new(:my_semaphore_2, :resources => 2, :redis => @redis) }


### PR DESCRIPTION
If you are creating semaphores dynamically, the keys do not naturally expire and will gradually build up in Redis. This assumes you don't have exceptionally long running critical sections as no expiration is set on the grabbed_key. In theory there could be some point within exists_or_create! where the exists_key expires between the getset and the renewal of the expiration, but this setting would be only appropriate when there is some definitive time the lock is no longer useful like a bidding window that has closed