### PR TITLE
Send TIME command to redis connection

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -190,7 +190,7 @@ class Redis
         Time.now
       else
         begin
-          instant = @redis.time
+          instant = redis_namespace? ? @redis.redis.time : @redis.time
           Time.at(instant[0], instant[1])
         rescue
           @use_local_time = true


### PR DESCRIPTION
This avoids warnings when using [Redis::Namespace](https://github.com/resque/redis-namespace):

> Passing 'time' command to redis as is; blind passthrough has been deprecated and will be removed in redis-namespace 2.0