### PR TITLE
Fixing available resources for non-locked semaphores

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -43,7 +43,11 @@ class Redis
     end
 
     def available_count
-      @redis.llen(available_key)
+      if exists?
+        @redis.llen(available_key)
+      else
+        @resource_count
+      end
     end
 
     def delete!

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -22,6 +22,10 @@ describe "redis" do
       expect(semaphore.available_count).to eq(1)
     end
 
+    it "has the correct amount of available resources before locking" do
+      expect(semaphore.available_count).to eq(1)
+    end
+
     it "should not exist from the start" do
       expect(semaphore.exists?).to eq(false)
       semaphore.lock


### PR DESCRIPTION
As discussed in #30, `available_count` will return `@resource_count` if a semaphore is created and never locked. With a test.