### PR TITLE
add internal mutex to Redis::Semaphore for handling threads

### DIFF
--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -262,15 +262,15 @@ describe "redis" do
         sequence = []
 
         t1 = Thread.new do
-          sleep(0.01)
-          sequence.push(Time.now.to_f)
           sleep(0.1)
+          sequence.push(Time.now.to_f)
+          sleep(1)
         end
 
         t2 = Thread.new do
-          sleep(0.01)
-          sequence.push(Time.now.to_f)
           sleep(0.1)
+          sequence.push(Time.now.to_f)
+          sleep(1)
         end
 
         expect(sequence.length).to eq(0)
@@ -288,24 +288,24 @@ describe "redis" do
 
         t1 = Thread.new do
           mutex.synchronize do
-            sleep(0.01)
-            sequence.push(Time.now.to_f)
             sleep(0.1)
+            sequence.push(Time.now.to_f)
+            sleep(1)
           end
         end
 
         t2 = Thread.new do
           mutex.synchronize do
-            sleep(0.01)
-            sequence.push(Time.now.to_f)
             sleep(0.1)
+            sequence.push(Time.now.to_f)
+            sleep(1)
           end
         end
 
         expect(sequence.length).to eq(0)
         [t1, t2].each(&:join)
         expect(sequence.length).to eq(2)
-        expect(sequence[1] - sequence[0]).to be > 0.1
+        expect(sequence[1] - sequence[0]).to be > 1
         [t1, t2].each(&:kill)
       end
     end
@@ -315,25 +315,25 @@ describe "redis" do
         sequence = []
 
         t1 = Thread.new do
-          semaphore.lock do
-            sleep(0.01)
-            sequence.push(Time.now.to_f)
+          semaphore.lock(1) do
             sleep(0.1)
+            sequence.push(Time.now.to_f)
+            sleep(1)
           end
         end
 
         t2 = Thread.new do
-          semaphore.lock do
-            sleep(0.01)
-            sequence.push(Time.now.to_f)
+          semaphore.lock(1) do
             sleep(0.1)
+            sequence.push(Time.now.to_f)
+            sleep(1)
           end
         end
 
         expect(sequence.length).to eq(0)
         [t1, t2].each(&:join)
         expect(sequence.length).to eq(2)
-        expect(sequence[1] - sequence[0]).to be > 0.1
+        expect(sequence[1] - sequence[0]).to be > 1
         [t1, t2].each(&:kill)
       end
     end

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -262,19 +262,21 @@ describe "redis" do
         sequence = []
 
         t1 = Thread.new do
+          sleep(0.01)
           sequence.push(Time.now.to_f)
-          sleep(1)
+          sleep(0.1)
         end
 
         t2 = Thread.new do
+          sleep(0.01)
           sequence.push(Time.now.to_f)
-          sleep(1)
+          sleep(0.1)
         end
 
         expect(sequence.length).to eq(0)
         [t1, t2].each(&:join)
         expect(sequence.length).to eq(2)
-        expect(sequence[1] - sequence[0]).to be < 0.1
+        expect(sequence[1] - sequence[0]).to be < 0.01
         [t1, t2].each(&:kill)
       end
     end
@@ -286,22 +288,24 @@ describe "redis" do
 
         t1 = Thread.new do
           mutex.synchronize do
+            sleep(0.01)
             sequence.push(Time.now.to_f)
-            sleep(1)
+            sleep(0.1)
           end
         end
 
         t2 = Thread.new do
           mutex.synchronize do
+            sleep(0.01)
             sequence.push(Time.now.to_f)
-            sleep(1)
+            sleep(0.1)
           end
         end
 
         expect(sequence.length).to eq(0)
         [t1, t2].each(&:join)
         expect(sequence.length).to eq(2)
-        expect(sequence[1] - sequence[0]).to be > 1
+        expect(sequence[1] - sequence[0]).to be > 0.1
         [t1, t2].each(&:kill)
       end
     end
@@ -312,22 +316,24 @@ describe "redis" do
 
         t1 = Thread.new do
           semaphore.lock do
+            sleep(0.01)
             sequence.push(Time.now.to_f)
-            sleep(1)
+            sleep(0.1)
           end
         end
 
         t2 = Thread.new do
           semaphore.lock do
+            sleep(0.01)
             sequence.push(Time.now.to_f)
-            sleep(1)
+            sleep(0.1)
           end
         end
 
         expect(sequence.length).to eq(0)
         [t1, t2].each(&:join)
         expect(sequence.length).to eq(2)
-        expect(sequence[1] - sequence[0]).to be > 1
+        expect(sequence[1] - sequence[0]).to be > 0.1
         [t1, t2].each(&:kill)
       end
     end

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -201,6 +201,10 @@ describe "redis" do
       Timecop.freeze(Time.local(1990))
     end
 
+    after(:all) do
+      Timecop.return
+    end
+
     it "with time support should return a different time than frozen time" do
       expect(semaphore.send(:current_time)).not_to eq(Time.now)
     end
@@ -247,4 +251,85 @@ describe "redis" do
     end
   end
 
+  describe "threaded behavior" do
+    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, redis: @redis) }
+
+    before { Thread.abort_on_exception = true }
+    after { Thread.abort_on_exception = false }
+
+    context "without semaphore" do
+      it "should allow simultaneous access by different threads" do
+        sequence = []
+
+        t1 = Thread.new do
+          sequence.push(Time.now.to_f)
+          sleep(1)
+        end
+
+        t2 = Thread.new do
+          sequence.push(Time.now.to_f)
+          sleep(1)
+        end
+
+        expect(sequence.length).to eq(0)
+        [t1, t2].each(&:join)
+        expect(sequence.length).to eq(2)
+        expect(sequence[1] - sequence[0]).to be < 0.1
+        [t1, t2].each(&:kill)
+      end
+    end
+
+    context "with ruby's mutex" do
+      it "should prevent simultaneous access by different threads" do
+        sequence = []
+        mutex = Mutex.new
+
+        t1 = Thread.new do
+          mutex.synchronize do
+            sequence.push(Time.now.to_f)
+            sleep(1)
+          end
+        end
+
+        t2 = Thread.new do
+          mutex.synchronize do
+            sequence.push(Time.now.to_f)
+            sleep(1)
+          end
+        end
+
+        expect(sequence.length).to eq(0)
+        [t1, t2].each(&:join)
+        expect(sequence.length).to eq(2)
+        expect(sequence[1] - sequence[0]).to be > 1
+        [t1, t2].each(&:kill)
+      end
+    end
+
+    context "with semaphore" do
+      it "should prevent simultaneous access by different threads" do
+        sequence = []
+
+        t1 = Thread.new do
+          semaphore.lock do
+            sequence.push(Time.now.to_f)
+            sleep(1)
+          end
+        end
+
+        t2 = Thread.new do
+          semaphore.lock do
+            sequence.push(Time.now.to_f)
+            sleep(1)
+          end
+        end
+
+        expect(sequence.length).to eq(0)
+        [t1, t2].each(&:join)
+        expect(sequence.length).to eq(2)
+        expect(sequence[1] - sequence[0]).to be > 1
+        [t1, t2].each(&:kill)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I encountered a problem with `redis-semaphore` when trying to use it to lock resources among processes that each have multiple threads. The core '#lock' method deadlocks if accessed in rapid succession within the same process. I added an internal mutex using Ruby's built-in `Mutex` class to guard against this case.

The tests I included demonstrate that the change makes `Redis::Semaphore` act like `Mutex` in terms of interacting with threads, which I would think would be the expected behavior. The last test fails without the internal mutex (you can try taking it out), that's the error condition I was running into.