### PR TITLE
Make exception more specific to suppress rspec warnings

### DIFF
--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -93,9 +93,9 @@ describe "redis" do
     it "should not leave the semaphore locked after raising an exception" do
       expect {
         semaphore.lock(1) do
-          raise Exception
+          raise Exception, "redis semaphore exception"
         end
-      }.to raise_error
+      }.to raise_error(Exception, "redis semaphore exception")
 
       expect(semaphore.locked?).to eq(false)
     end


### PR DESCRIPTION
Without this I get the following warning when running the specs:
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /Users/tomclose/zesty/redis-semaphore/spec/semaphore_spec.rb:95:in `block (3 levels) in <top (required)>'.
```