### PR TITLE
Fix Stack level too deep after sem.lock(0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ rvm:
   - rbx
 services:
   - redis-server
+before_install:
+  - gem install bundler

--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -62,14 +62,13 @@ class Redis
 
       if timeout.nil? || timeout > 0
         # passing timeout 0 to blpop causes it to block
-        token_pair = @redis.blpop(available_key, timeout || 0)
+        _key, current_token = @redis.blpop(available_key, timeout || 0)
       else
-        token_pair = @redis.lpop(available_key)
+        current_token = @redis.lpop(available_key)
       end
 
-      return false if token_pair.nil?
+      return false if current_token.nil?
 
-      current_token = token_pair[1]
       @tokens.push(current_token)
       @redis.hset(grabbed_key, current_token, current_time.to_f)
       return_value = current_token

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -137,6 +137,12 @@ describe "redis" do
 
       expect(did_we_get_in).to be false
     end
+
+    it "should be locked when the timeout is zero" do
+      semaphore.lock(0) do
+        expect(semaphore.locked?).to be true
+      end
+    end
   end
 
   describe "semaphore with expiration" do


### PR DESCRIPTION
This shall fix #40.

While `blpop` returns a pair of the token and the `available_key`, `lpop` only
returns a single value (the token). Since we only need the token, we set
the `current_token ` in the if/else statement.