### PR TITLE
Protect vs resource leakage

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -77,7 +77,7 @@ class Redis
         begin
           return_value = yield current_token
         ensure
-          signal(current_token)
+          signal(current_token) if locked?(current_token)
         end
       end
 

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -219,6 +219,21 @@ describe "redis" do
       expect(hyper_aggressive_sem.lock(1)).to eq(false)
       expect(hyper_aggressive_sem.lock(1)).not_to eq(false)
     end
+
+    it "should not add extra resources from stale clients" do
+      hyper_aggressive_sem = Redis::Semaphore.new(
+        :my_semaphore_2,
+        redis: @redis,
+        stale_client_timeout: 0.1
+      )
+
+      expect do
+        multisem.lock do
+          sleep 0.1
+          hyper_aggressive_sem.release_stale_locks!
+        end
+      end.not_to change(multisem, :available_count)
+    end
   end
 
   describe "redis time" do


### PR DESCRIPTION
Previously, if a semaphore was given a block and then went stale, but
eventually completed it's task, it would add a duplicate of its' token
to the available pool. Additionally, any codebase that only used the
block structure would not self-heal from this state.

Non-block usage would self-heal thanks to the unlock method.

fixes #48 and  #10