### PR TITLE
Stale timed out semaphores add extra availability keys when completed

### DIFF
--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -207,9 +207,13 @@ describe "redis" do
   end
 
   describe "semaphore took too long and was evicted" do
-    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, :redis => @redis) }
+    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, redis: @redis) }
     it "does not re-add it's availability key if that job is completed" do
-      watchdog = Redis::Semaphore.new(:my_semaphore, :redis => @redis, :stale_client_timeout => 1)
+      watchdog = Redis::Semaphore.new(
+        :my_semaphore,
+        redis: @redis,
+        stale_client_timeout: 1
+      )
       semaphore.lock do
         sleep 1.1
         watchdog.release_stale_locks!


### PR DESCRIPTION
If a stale semaphore job's lock gets released through a release_stale_locks! call before it is completed and then it completes, it would add the lock's availability key back into the availability list even though that availability key has been added by the release_stale_locks! call prior.

This fixes that situation by verifying redis's grabbed timestamp against this lock's grabbed time.