### PR TITLE
Fix key expire timing

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -201,7 +201,7 @@ class Redis
 
     def set_expiration_if_necessary
       if @expiration
-        [available_key, exists_key, version_key].each do |key|
+        [exists_key, available_key, version_key].each do |key|
           @redis.expire(key, @expiration)
         end
       end

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -8,6 +8,7 @@ describe "redis" do
 
   before(:each) do
     @redis.flushdb
+    stub_const("Redis::Semaphore::EXPIRATION_DELAY", 0)
   end
 
   after(:all) do

--- a/spec/semaphore_spec.rb
+++ b/spec/semaphore_spec.rb
@@ -207,9 +207,13 @@ describe "redis" do
   end
 
   describe "semaphore took too long and was evicted" do
-    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, :redis => @redis) }
+    let(:semaphore) { Redis::Semaphore.new(:my_semaphore, redis: @redis) }
     it "does not re-add it's availability key if that job is completed" do
-      watchdog = Redis::Semaphore.new(:my_semaphore, :redis => @redis, :stale_client_timeout => 1)
+      watchdog = Redis::Semaphore.new(
+        :my_semaphore,
+        redis: @redis,
+        stale_client_timeout: 1
+      )
       semaphore.lock do
         sleep 1.1
         watchdog.release_stale_locks!


### PR DESCRIPTION
See https://github.com/EnjoyTech/redis-semaphore/pull/2 for overview of how redis-semaphore works and original change to expire the exists key prior to the available key.

Although the fix above fixed one race condition, it introduced another, which is that the available key expires in between the time a lock is initialized (when it checks and sees the exists key is present) and the time it grabs a resource off the available key's queue. It thus has no resource to grab, and hangs forever.

So let's say a semaphore with the name "FOO" is created with an expiration of one minute, and then re-invoked one minute later. Here is what can happen.

- `FOO` semaphore initialized
- `SEMAPHORE:FOO:EXISTS` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:AVAILABLE` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:VERSION` initialized w/ 1 minute expiration
- `SEMAPHORE:FOO:GRABBED` initialized but deletes as soon as semaphore released
- 1 minute passes
- `FOO` semaphore invoked again before any keys expire
- determines that `SEMAPHORE:FOO:EXISTS` key is still valid, so does not re-initialize semaphore
- `SEMAPHORE:FOO:EXISTS` expiration passes, but its expiration was extended as part of the check in the prior step, so it does not expire
- `SEMAPHORE:FOO:AVAILABLE` expires, since nothing has touched it yet
- new semaphore goes to pop a resource off `SEMAPHORE:FOO:AVAILABLE`, but since it was expired, it is empty and blocks forever
- bad stuff happens

This PR delays the expiration of the available key (and the version key, which is entirely irrelevant) by 10 seconds from the time the exists key is expired.

If the exists key expires (and the available key hasn't expired), a new invocation will delete and re-initialize the available key anyway. Expiring the available key is thus not urgent, just a matter of cleanup.

Testing

- [x] Run gem's tests
- [x] Manually test in console with Gemfile pointed to local code and ensure lock still works.
- [x] Manual hacking to artificially delay the time between checking the exists key and grabbing a resource with a sleep call.  To reproduce, locked with first semaphore with a relatively short expiration, then locked with 2nd so that available key expiration from the first will expire during the added sleep call. After making the fix, unable to reproduce the problem in the same manner.