### PR TITLE
Fix annoying deprecation messages

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -111,11 +111,11 @@ class Redis
     def signal(token = 1)
       token ||= generate_unique_token
 
-      @redis.multi do |transaction|
-        transaction.hdel grabbed_key, token
-        transaction.lpush available_key, token
+      @redis.multi do |pipeline|
+        pipeline.hdel grabbed_key, token
+        pipeline.lpush available_key, token
 
-        set_expiration_if_necessary(transaction)
+        set_expiration_if_necessary(pipeline)
       end
     end
 
@@ -124,9 +124,9 @@ class Redis
     end
 
     def all_tokens
-      @redis.multi do |transaction|
-        transaction.lrange(available_key, 0, -1)
-        transaction.hkeys(grabbed_key)
+      @redis.multi do |pipeline|
+        pipeline.lrange(available_key, 0, -1)
+        pipeline.hkeys(grabbed_key)
       end.flatten
     end
 
@@ -190,23 +190,23 @@ class Redis
     def create!
       @redis.expire(exists_key, 10)
 
-      @redis.multi do |transaction|
-        transaction.del(grabbed_key)
-        transaction.del(available_key)
+      @redis.multi do |pipeline|
+        pipeline.del(grabbed_key)
+        pipeline.del(available_key)
         @resource_count.times do |index|
-          transaction.rpush(available_key, index)
+          pipeline.rpush(available_key, index)
         end
-        transaction.set(version_key, API_VERSION)
-        transaction.persist(exists_key)
+        pipeline.set(version_key, API_VERSION)
+        pipeline.persist(exists_key)
 
-        set_expiration_if_necessary(transaction)
+        set_expiration_if_necessary(pipeline)
       end
     end
 
-    def set_expiration_if_necessary(transaction = @redis)
+    def set_expiration_if_necessary(pipeline = @redis)
       if @expiration
         [available_key, exists_key, version_key].each do |key|
-          transaction.expire(key, @expiration)
+          pipeline.expire(key, @expiration)
         end
       end
     end

--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -111,11 +111,11 @@ class Redis
     def signal(token = 1)
       token ||= generate_unique_token
 
-      @redis.multi do
-        @redis.hdel grabbed_key, token
-        @redis.lpush available_key, token
+      @redis.multi do |pipeline|
+        pipeline.hdel grabbed_key, token
+        pipeline.lpush available_key, token
 
-        set_expiration_if_necessary
+        set_expiration_if_necessary(pipeline)
       end
     end
 
@@ -124,9 +124,9 @@ class Redis
     end
 
     def all_tokens
-      @redis.multi do
-        @redis.lrange(available_key, 0, -1)
-        @redis.hkeys(grabbed_key)
+      @redis.multi do |pipeline|
+        pipeline.lrange(available_key, 0, -1)
+        pipeline.hkeys(grabbed_key)
       end.flatten
     end
 
@@ -190,23 +190,23 @@ class Redis
     def create!
       @redis.expire(exists_key, 10)
 
-      @redis.multi do
-        @redis.del(grabbed_key)
-        @redis.del(available_key)
+      @redis.multi do |pipeline|
+        pipeline.del(grabbed_key)
+        pipeline.del(available_key)
         @resource_count.times do |index|
-          @redis.rpush(available_key, index)
+          pipeline.rpush(available_key, index)
         end
-        @redis.set(version_key, API_VERSION)
-        @redis.persist(exists_key)
+        pipeline.set(version_key, API_VERSION)
+        pipeline.persist(exists_key)
 
-        set_expiration_if_necessary
+        set_expiration_if_necessary(pipeline)
       end
     end
 
-    def set_expiration_if_necessary
+    def set_expiration_if_necessary(pipeline = @redis)
       if @expiration
         [available_key, exists_key, version_key].each do |key|
-          @redis.expire(key, @expiration)
+          pipeline.expire(key, @expiration)
         end
       end
     end

--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -64,7 +64,7 @@ class Redis
 
       if timeout.nil? || timeout > 0
         # passing timeout 0 to blpop causes it to block
-        _key, current_token = @redis.blpop(available_key, timeout: timeout || 0)
+        _key, current_token = @redis.blpop(available_key, timeout || 0)
       else
         current_token = @redis.lpop(available_key)
       end

--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -64,7 +64,7 @@ class Redis
 
       if timeout.nil? || timeout > 0
         # passing timeout 0 to blpop causes it to block
-        _key, current_token = @redis.blpop(available_key, timeout || 0)
+        _key, current_token = @redis.blpop(available_key, timeout: timeout || 0)
       else
         current_token = @redis.lpop(available_key)
       end


### PR DESCRIPTION
When running tests, we get a lot of dprecation notices like these:


(called from /Users/rolandstuder/code/redis-semaphore/lib/redis/semaphore.rb:114:in `signal'}
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.


```ruby
redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end
```

And 

```ruby
(called from /Users/rolandstuder/.local/share/rtx/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/bundler/gems/redis-semaphore-bbf637537d9c/lib/redis/semaphore.rb:114:in `signal'}
Passing the timeout as a positional argument is deprecated, it should be passed as a keyword argument:
  redis.blpop("SEMAPHORE:Merchant10:AVAILABLE", timeout: 30)(called from: /Users/rolandstuder/.local/share/rtx/installs/ruby/3.3.7/lib/ruby/gems/3.3.0/bundler/gems/redis-semaphore-bbf637537d9c/lib/redis/semaphore.rb:67:in `lock')
```

This PR updates to gem, so we don't have them anymore.

The commits are a mess, because I accidently first push to master, so I had to revert and then rever the reverts. I was not sure if I should just rewrite the history on master.